### PR TITLE
Split `dns` check into smaller checks

### DIFF
--- a/lib/check/a.py
+++ b/lib/check/a.py
@@ -9,5 +9,5 @@ async def check_a(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/a.py
+++ b/lib/check/a.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'A'
+
+
+async def check_a(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/aaaa.py
+++ b/lib/check/aaaa.py
@@ -9,5 +9,5 @@ async def check_aaaa(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/aaaa.py
+++ b/lib/check/aaaa.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'AAAA'
+
+
+async def check_aaaa(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/caa.py
+++ b/lib/check/caa.py
@@ -9,5 +9,5 @@ async def check_caa(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/caa.py
+++ b/lib/check/caa.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'CAA'
+
+
+async def check_caa(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/cname.py
+++ b/lib/check/cname.py
@@ -9,5 +9,5 @@ async def check_cname(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, True)
     return res

--- a/lib/check/cname.py
+++ b/lib/check/cname.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'CNAME'
+
+
+async def check_cname(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/ds.py
+++ b/lib/check/ds.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'DS'
+
+
+async def check_ds(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/ds.py
+++ b/lib/check/ds.py
@@ -9,5 +9,5 @@ async def check_ds(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/mx.py
+++ b/lib/check/mx.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'MX'
+
+
+async def check_mx(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/mx.py
+++ b/lib/check/mx.py
@@ -9,5 +9,5 @@ async def check_mx(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/ns.py
+++ b/lib/check/ns.py
@@ -9,5 +9,5 @@ async def check_ns(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/ns.py
+++ b/lib/check/ns.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'NS'
+
+
+async def check_ns(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/ptr.py
+++ b/lib/check/ptr.py
@@ -9,5 +9,5 @@ async def check_ptr(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, True)
     return res

--- a/lib/check/ptr.py
+++ b/lib/check/ptr.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'PTR'
+
+
+async def check_ptr(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/soa.py
+++ b/lib/check/soa.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'SOA'
+
+
+async def check_soa(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/soa.py
+++ b/lib/check/soa.py
@@ -9,5 +9,5 @@ async def check_soa(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/srv.py
+++ b/lib/check/srv.py
@@ -9,5 +9,5 @@ async def check_srv(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/srv.py
+++ b/lib/check/srv.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'SRV'
+
+
+async def check_srv(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/check/txt.py
+++ b/lib/check/txt.py
@@ -9,5 +9,5 @@ async def check_txt(
         asset: Asset,
         asset_config: dict,
         check_config: dict) -> dict:
-    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    res = await dns_check(asset, asset_config, check_config, QTYPE, False)
     return res

--- a/lib/check/txt.py
+++ b/lib/check/txt.py
@@ -1,0 +1,13 @@
+from libprobe.asset import Asset
+from ..utils import dns_check
+
+
+QTYPE = 'TXT'
+
+
+async def check_txt(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict) -> dict:
+    res = await dns_check(asset, asset_config, check_config, QTYPE)
+    return res

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,0 +1,84 @@
+import logging
+from typing import Optional
+from libprobe.asset import Asset
+import asyncio
+import dns.asyncresolver
+import dns.message
+from dns.resolver import NoAnswer
+from libprobe.exceptions import (
+    CheckException,
+    IgnoreCheckException,
+    IncompleteResultException,
+)
+
+
+def get_item(timeit: float, answers: int, item: dict) -> dict:
+    item['timeit'] = timeit
+    return item
+
+
+async def dns_single(loop, aresolver, qname, qtype, item) -> Optional[dict]:
+    start = loop.time()
+    try:
+        response = (await aresolver.resolve(qname, qtype)).response
+    except NoAnswer:
+        return None
+    except Exception as e:
+        msg = str(e) or type(e).__name__
+        raise CheckException(msg)  # this might result in a incomplete result
+    else:
+        record = response.answer[0].to_rdataset()[0]
+        item[qtype] = str(record)
+        item['timeit'] = loop.time() - start
+
+
+async def dns_query(qname: str, qtype: str, name_server: str):
+    aresolver = dns.asyncresolver.Resolver()
+    try:
+        aresolver.nameservers = [name_server]
+    except ValueError as e:
+        raise CheckException(str(e))
+
+    loop = asyncio.get_event_loop()
+    item = {
+        'name': name_server,
+        'query': qname,
+    }
+    await dns_single(loop, aresolver, qname, qtype, item)
+    return item
+
+
+async def dns_check(
+        asset: Asset,
+        asset_config: dict,
+        check_config: dict,
+        qtype: str) -> dict:
+    name_servers = check_config.get('nameServers')
+    if not name_servers or not isinstance(name_servers, (tuple, list)):
+        logging.warning(
+            'Check did not run; '
+            'nameServers is not provided, invalid or empty')
+        raise IgnoreCheckException
+
+    qname = check_config.get('fqdn')
+    if not qname:
+        qname = asset.name
+
+    type_name = qtype.lower()
+
+    items = []
+    result = {type_name: items}
+    check_exc: Optional[CheckException] = None
+    for name_server in name_servers:
+        try:
+            item = await dns_query(qname, qtype, name_server)
+        except CheckException as e:
+            check_exc = e
+        else:
+            items.append(item)
+
+    if check_exc is None:
+        return result
+    elif items:
+        raise IncompleteResultException(str(check_exc), result)
+    raise check_exc

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -12,11 +12,6 @@ from libprobe.exceptions import (
 )
 
 
-def get_item(timeit: float, answers: int, item: dict) -> dict:
-    item['timeit'] = timeit
-    return item
-
-
 async def _time_dns(loop, aresolver, qname, qtype, item,
                     single) -> Optional[dict]:
     start = loop.time()

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,4 +1,4 @@
 # Version string. Examples:
 #  '3.0.0'
 #  '3.0.0-alpha9'
-__version__ = '3.0.2'
+__version__ = '3.0.3-alpha0'

--- a/main.py
+++ b/main.py
@@ -16,18 +16,18 @@ from lib.version import __version__ as version
 
 if __name__ == '__main__':
     checks = {
-        'a': check_a,
-        'aaaa': check_aaaa,
-        'caa': check_caa,
-        'cname': check_cname,
+        'A': check_a,
+        'AAAA': check_aaaa,
+        'CAA': check_caa,
+        'CNAME': check_cname,
         'dns': check_dns,
-        'ds': check_ds,
-        'mx': check_mx,
-        'ns': check_ns,
-        'ptr': check_ptr,
-        'soa': check_soa,
-        'srv': check_srv,
-        'txt': check_txt,
+        'DS': check_ds,
+        'MX': check_mx,
+        'NS': check_ns,
+        'PTR': check_ptr,
+        'SOA': check_soa,
+        'SRV': check_srv,
+        'TXT': check_txt,
     }
 
     probe = Probe("dns", version, checks)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,34 @@
 from libprobe.probe import Probe
+from lib.check.a import check_a
+from lib.check.aaaa import check_aaaa
+from lib.check.caa import check_caa
+from lib.check.cname import check_cname
 from lib.check.dns import check_dns
+from lib.check.ds import check_ds
+from lib.check.mx import check_mx
+from lib.check.ns import check_ns
+from lib.check.ptr import check_ptr
+from lib.check.soa import check_soa
+from lib.check.srv import check_srv
+from lib.check.txt import check_txt
 from lib.version import __version__ as version
 
 
 if __name__ == '__main__':
-    checks = {'dns': check_dns}
+    checks = {
+        'a': check_a,
+        'aaaa': check_aaaa,
+        'caa': check_caa,
+        'cname': check_cname,
+        'dns': check_dns,
+        'ds': check_ds,
+        'mx': check_mx,
+        'ns': check_ns,
+        'ptr': check_ptr,
+        'soa': check_soa,
+        'srv': check_srv,
+        'txt': check_txt,
+    }
 
     probe = Probe("dns", version, checks)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-libprobe==0.2.29
-dnspython==2.2.1
+libprobe==0.2.33
+dnspython==2.4.0

--- a/test_dns.py
+++ b/test_dns.py
@@ -62,7 +62,10 @@ class TestProbe(unittest.TestCase):
         except IncompleteResultException as e:
             result = e.result
             self.assertIn('CNAME', result['dns'][0])
-            self.assertRegex(str(e), r'nameserver 0.0 is not an IP address')
+            self.assertRegex(
+                str(e),
+                r'nameserver 0.0 is not a dns.nameserver.Nameserver '
+                r'instance or text form, IP address, nor a valid https URL')
         else:
             raise Exception('IncompleteResultException not raised')
 


### PR DESCRIPTION
## Description

Splits the `dns` check in several smaller checks.

## Type of change

- [x] We keep the `old` check for backwards compatibility but needs to be removed later.

## How Has This Been Tested?

- [x] Tested in development and the service 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
